### PR TITLE
add prepass texture bindings

### DIFF
--- a/crates/bevy_core_pipeline/src/core_3d/main_pass_3d_node.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/main_pass_3d_node.rs
@@ -14,12 +14,13 @@ use bevy_render::{
 #[cfg(feature = "trace")]
 use bevy_utils::tracing::info_span;
 
-/// Add a DepthPrepassSettings component to a view to perform a depth prepass and use it in a main
+/// Add a `DepthPrepassSettings` component to a view to perform a depth prepass and use it in a main
 /// pass to reduce overdraw for opaque meshes.
 #[derive(Clone, Component)]
 pub struct DepthPrepassSettings {
-    /// If true then a ViewNormalsTexture component will be added to the view, and the world
-    /// normals will be output from the depth prepass for use in subsequent passes.
+    /// if true then depth values will be copied to a separate texture available to the main pass
+    pub depth_resource: bool,
+    /// If true then vertex world normals will be output from the depth prepass for use in subsequent passes.
     pub output_normals: bool,
 }
 

--- a/crates/bevy_core_pipeline/src/core_3d/mod.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/mod.rs
@@ -227,7 +227,7 @@ pub fn prepare_core_3d_depth_textures(
     msaa: Res<Msaa>,
     render_device: Res<RenderDevice>,
     views_3d: Query<
-        (Entity, &ExtractedCamera),
+        (Entity, &ExtractedCamera, Option<&DepthPrepassSettings>),
         (
             With<RenderPhase<Opaque3d>>,
             With<RenderPhase<AlphaMask3d>>,
@@ -236,11 +236,15 @@ pub fn prepare_core_3d_depth_textures(
     >,
 ) {
     let mut textures = HashMap::default();
-    for (entity, camera) in &views_3d {
+    for (entity, camera, maybe_prepass) in &views_3d {
         if let Some(physical_target_size) = camera.physical_target_size {
             let cached_texture = textures
                 .entry(camera.target.clone())
                 .or_insert_with(|| {
+                    let mut usage = TextureUsages::RENDER_ATTACHMENT;
+                    if maybe_prepass.map_or(false, |prepass_settings| prepass_settings.depth_resource) {
+                        usage |= TextureUsages::COPY_SRC;
+                    }
                     texture_cache.get(
                         &render_device,
                         TextureDescriptor {
@@ -255,7 +259,7 @@ pub fn prepare_core_3d_depth_textures(
                             dimension: TextureDimension::D2,
                             format: TextureFormat::Depth32Float, /* PERF: vulkan docs recommend using 24
                                                                   * bit depth for better performance */
-                            usage: TextureUsages::RENDER_ATTACHMENT,
+                            usage,
                         },
                     )
                 })

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -1,7 +1,7 @@
 use crate::{
     GlobalLightMeta, GpuLights, GpuPointLights, LightMeta, NotShadowCaster, NotShadowReceiver,
-    ShadowPipeline, ViewClusterBindings, ViewLightsUniformOffset, ViewShadowBindings,
-    CLUSTERED_FORWARD_STORAGE_BUFFER_COUNT,
+    ShadowPipeline, ViewClusterBindings, ViewLightsUniformOffset, ViewPrepassTextures,
+    ViewShadowBindings, CLUSTERED_FORWARD_STORAGE_BUFFER_COUNT,
 };
 use bevy_app::Plugin;
 use bevy_asset::{load_internal_asset, Assets, Handle, HandleUntyped};
@@ -17,12 +17,14 @@ use bevy_render::{
         skinning::{SkinnedMesh, SkinnedMeshInverseBindposes},
         GpuBufferInfo, Mesh, MeshVertexBufferLayout,
     },
+    prelude::Msaa,
     render_asset::RenderAssets,
     render_phase::{EntityRenderCommand, RenderCommandResult, TrackedRenderPass},
     render_resource::*,
     renderer::{RenderDevice, RenderQueue},
     texture::{
-        BevyDefault, DefaultImageSampler, GpuImage, Image, ImageSampler, TextureFormatPixelInfo,
+        BevyDefault, DefaultImageSampler, FallbackImagesDepth, FallbackImagesMsaa, GpuImage, Image,
+        ImageSampler, TextureFormatPixelInfo,
     },
     view::{ComputedVisibility, ViewUniform, ViewUniformOffset, ViewUniforms},
     Extract, RenderApp, RenderStage,
@@ -256,6 +258,7 @@ pub fn extract_skinned_meshes(
 #[derive(Resource, Clone)]
 pub struct MeshPipeline {
     pub view_layout: BindGroupLayout,
+    pub view_layout_multisampled: BindGroupLayout,
     pub mesh_layout: BindGroupLayout,
     pub skinned_mesh_layout: BindGroupLayout,
     // This dummy white texture is to be used in place of optional StandardMaterial textures
@@ -274,118 +277,160 @@ impl FromWorld for MeshPipeline {
         let clustered_forward_buffer_binding_type = render_device
             .get_supported_read_only_binding_type(CLUSTERED_FORWARD_STORAGE_BUFFER_COUNT);
 
-        let view_layout = render_device.create_bind_group_layout(&BindGroupLayoutDescriptor {
-            entries: &[
-                // View
-                BindGroupLayoutEntry {
-                    binding: 0,
-                    visibility: ShaderStages::VERTEX | ShaderStages::FRAGMENT,
-                    ty: BindingType::Buffer {
-                        ty: BufferBindingType::Uniform,
-                        has_dynamic_offset: true,
-                        min_binding_size: Some(ViewUniform::min_size()),
-                    },
-                    count: None,
+        let mut layout_entries = vec![
+            // View
+            BindGroupLayoutEntry {
+                binding: 0,
+                visibility: ShaderStages::VERTEX | ShaderStages::FRAGMENT,
+                ty: BindingType::Buffer {
+                    ty: BufferBindingType::Uniform,
+                    has_dynamic_offset: true,
+                    min_binding_size: Some(ViewUniform::min_size()),
                 },
-                // Lights
-                BindGroupLayoutEntry {
-                    binding: 1,
-                    visibility: ShaderStages::FRAGMENT,
-                    ty: BindingType::Buffer {
-                        ty: BufferBindingType::Uniform,
-                        has_dynamic_offset: true,
-                        min_binding_size: Some(GpuLights::min_size()),
-                    },
-                    count: None,
+                count: None,
+            },
+            // Lights
+            BindGroupLayoutEntry {
+                binding: 1,
+                visibility: ShaderStages::FRAGMENT,
+                ty: BindingType::Buffer {
+                    ty: BufferBindingType::Uniform,
+                    has_dynamic_offset: true,
+                    min_binding_size: Some(GpuLights::min_size()),
                 },
-                // Point Shadow Texture Cube Array
-                BindGroupLayoutEntry {
-                    binding: 2,
-                    visibility: ShaderStages::FRAGMENT,
-                    ty: BindingType::Texture {
-                        multisampled: false,
-                        sample_type: TextureSampleType::Depth,
-                        #[cfg(not(feature = "webgl"))]
-                        view_dimension: TextureViewDimension::CubeArray,
-                        #[cfg(feature = "webgl")]
-                        view_dimension: TextureViewDimension::Cube,
-                    },
-                    count: None,
+                count: None,
+            },
+            // Point Shadow Texture Cube Array
+            BindGroupLayoutEntry {
+                binding: 2,
+                visibility: ShaderStages::FRAGMENT,
+                ty: BindingType::Texture {
+                    multisampled: false,
+                    sample_type: TextureSampleType::Depth,
+                    #[cfg(not(feature = "webgl"))]
+                    view_dimension: TextureViewDimension::CubeArray,
+                    #[cfg(feature = "webgl")]
+                    view_dimension: TextureViewDimension::Cube,
                 },
-                // Point Shadow Texture Array Sampler
-                BindGroupLayoutEntry {
-                    binding: 3,
-                    visibility: ShaderStages::FRAGMENT,
-                    ty: BindingType::Sampler(SamplerBindingType::Comparison),
-                    count: None,
+                count: None,
+            },
+            // Point Shadow Texture Array Sampler
+            BindGroupLayoutEntry {
+                binding: 3,
+                visibility: ShaderStages::FRAGMENT,
+                ty: BindingType::Sampler(SamplerBindingType::Comparison),
+                count: None,
+            },
+            // Directional Shadow Texture Array
+            BindGroupLayoutEntry {
+                binding: 4,
+                visibility: ShaderStages::FRAGMENT,
+                ty: BindingType::Texture {
+                    multisampled: false,
+                    sample_type: TextureSampleType::Depth,
+                    #[cfg(not(feature = "webgl"))]
+                    view_dimension: TextureViewDimension::D2Array,
+                    #[cfg(feature = "webgl")]
+                    view_dimension: TextureViewDimension::D2,
                 },
-                // Directional Shadow Texture Array
-                BindGroupLayoutEntry {
-                    binding: 4,
-                    visibility: ShaderStages::FRAGMENT,
-                    ty: BindingType::Texture {
-                        multisampled: false,
-                        sample_type: TextureSampleType::Depth,
-                        #[cfg(not(feature = "webgl"))]
-                        view_dimension: TextureViewDimension::D2Array,
-                        #[cfg(feature = "webgl")]
-                        view_dimension: TextureViewDimension::D2,
-                    },
-                    count: None,
+                count: None,
+            },
+            // Directional Shadow Texture Array Sampler
+            BindGroupLayoutEntry {
+                binding: 5,
+                visibility: ShaderStages::FRAGMENT,
+                ty: BindingType::Sampler(SamplerBindingType::Comparison),
+                count: None,
+            },
+            // PointLights
+            BindGroupLayoutEntry {
+                binding: 6,
+                visibility: ShaderStages::FRAGMENT,
+                ty: BindingType::Buffer {
+                    ty: clustered_forward_buffer_binding_type,
+                    has_dynamic_offset: false,
+                    min_binding_size: Some(GpuPointLights::min_size(
+                        clustered_forward_buffer_binding_type,
+                    )),
                 },
-                // Directional Shadow Texture Array Sampler
-                BindGroupLayoutEntry {
-                    binding: 5,
-                    visibility: ShaderStages::FRAGMENT,
-                    ty: BindingType::Sampler(SamplerBindingType::Comparison),
-                    count: None,
-                },
-                // PointLights
-                BindGroupLayoutEntry {
-                    binding: 6,
-                    visibility: ShaderStages::FRAGMENT,
-                    ty: BindingType::Buffer {
-                        ty: clustered_forward_buffer_binding_type,
-                        has_dynamic_offset: false,
-                        min_binding_size: Some(GpuPointLights::min_size(
+                count: None,
+            },
+            // ClusteredLightIndexLists
+            BindGroupLayoutEntry {
+                binding: 7,
+                visibility: ShaderStages::FRAGMENT,
+                ty: BindingType::Buffer {
+                    ty: clustered_forward_buffer_binding_type,
+                    has_dynamic_offset: false,
+                    min_binding_size: Some(
+                        ViewClusterBindings::min_size_cluster_light_index_lists(
                             clustered_forward_buffer_binding_type,
-                        )),
-                    },
-                    count: None,
-                },
-                // ClusteredLightIndexLists
-                BindGroupLayoutEntry {
-                    binding: 7,
-                    visibility: ShaderStages::FRAGMENT,
-                    ty: BindingType::Buffer {
-                        ty: clustered_forward_buffer_binding_type,
-                        has_dynamic_offset: false,
-                        min_binding_size: Some(
-                            ViewClusterBindings::min_size_cluster_light_index_lists(
-                                clustered_forward_buffer_binding_type,
-                            ),
                         ),
-                    },
-                    count: None,
+                    ),
                 },
-                // ClusterOffsetsAndCounts
-                BindGroupLayoutEntry {
-                    binding: 8,
-                    visibility: ShaderStages::FRAGMENT,
-                    ty: BindingType::Buffer {
-                        ty: clustered_forward_buffer_binding_type,
-                        has_dynamic_offset: false,
-                        min_binding_size: Some(
-                            ViewClusterBindings::min_size_cluster_offsets_and_counts(
-                                clustered_forward_buffer_binding_type,
-                            ),
+                count: None,
+            },
+            // ClusterOffsetsAndCounts
+            BindGroupLayoutEntry {
+                binding: 8,
+                visibility: ShaderStages::FRAGMENT,
+                ty: BindingType::Buffer {
+                    ty: clustered_forward_buffer_binding_type,
+                    has_dynamic_offset: false,
+                    min_binding_size: Some(
+                        ViewClusterBindings::min_size_cluster_offsets_and_counts(
+                            clustered_forward_buffer_binding_type,
                         ),
-                    },
-                    count: None,
+                    ),
                 },
-            ],
+                count: None,
+            },
+            // depth texture
+            BindGroupLayoutEntry {
+                binding: 9,
+                visibility: ShaderStages::FRAGMENT,
+                ty: BindingType::Texture {
+                    multisampled: false,
+                    sample_type: TextureSampleType::Depth,
+                    view_dimension: TextureViewDimension::D2,
+                },
+                count: None,
+            },
+            // normal texture
+            BindGroupLayoutEntry {
+                binding: 10,
+                visibility: ShaderStages::FRAGMENT,
+                ty: BindingType::Texture {
+                    multisampled: false,
+                    sample_type: TextureSampleType::Float { filterable: true },
+                    view_dimension: TextureViewDimension::D2,
+                },
+                count: None,
+            },
+        ];
+
+        let view_layout = render_device.create_bind_group_layout(&BindGroupLayoutDescriptor {
             label: Some("mesh_view_layout"),
+            entries: &layout_entries,
         });
+
+        // modify for multisampled
+        layout_entries[9].ty = BindingType::Texture {
+            multisampled: true,
+            sample_type: TextureSampleType::Depth,
+            view_dimension: TextureViewDimension::D2,
+        };
+        layout_entries[10].ty = BindingType::Texture {
+            multisampled: true,
+            sample_type: TextureSampleType::Float { filterable: true },
+            view_dimension: TextureViewDimension::D2,
+        };
+
+        let view_layout_multisampled =
+            render_device.create_bind_group_layout(&BindGroupLayoutDescriptor {
+                label: Some("mesh_view_layout_multisampled"),
+                entries: &layout_entries,
+            });
 
         let mesh_binding = BindGroupLayoutEntry {
             binding: 0,
@@ -471,6 +516,7 @@ impl FromWorld for MeshPipeline {
         };
         MeshPipeline {
             view_layout,
+            view_layout_multisampled,
             mesh_layout,
             skinned_mesh_layout,
             clustered_forward_buffer_binding_type,
@@ -577,7 +623,14 @@ impl SpecializedMeshPipeline for MeshPipeline {
             vertex_attributes.push(Mesh::ATTRIBUTE_COLOR.at_shader_location(4));
         }
 
-        let mut bind_group_layout = vec![self.view_layout.clone()];
+        let mut bind_group_layout = match key.msaa_samples() {
+            1 => vec![self.view_layout.clone()],
+            _ => {
+                shader_defs.push("MULTISAMPLED".into());
+                vec![self.view_layout_multisampled.clone()]
+            }
+        };
+
         if layout.contains(Mesh::ATTRIBUTE_JOINT_INDEX)
             && layout.contains(Mesh::ATTRIBUTE_JOINT_WEIGHT)
         {
@@ -769,14 +822,53 @@ pub fn queue_mesh_view_bind_groups(
     light_meta: Res<LightMeta>,
     global_light_meta: Res<GlobalLightMeta>,
     view_uniforms: Res<ViewUniforms>,
-    views: Query<(Entity, &ViewShadowBindings, &ViewClusterBindings)>,
+    views: Query<(
+        Entity,
+        &ViewShadowBindings,
+        &ViewClusterBindings,
+        Option<&ViewPrepassTextures>,
+    )>,
+    mut fallback_images: FallbackImagesMsaa,
+    mut fallback_depths: FallbackImagesDepth,
+    msaa: Res<Msaa>,
 ) {
     if let (Some(view_binding), Some(light_binding), Some(point_light_binding)) = (
         view_uniforms.uniforms.binding(),
         light_meta.view_gpu_lights.binding(),
         global_light_meta.gpu_point_lights.binding(),
     ) {
-        for (entity, view_shadow_bindings, view_cluster_bindings) in &views {
+        for (entity, view_shadow_bindings, view_cluster_bindings, maybe_prepass_textures) in &views
+        {
+            let depth_view = if let Some(ViewPrepassTextures {
+                depth: Some(depth_prepass),
+                ..
+            }) = &maybe_prepass_textures
+            {
+                &depth_prepass.default_view
+            } else {
+                &fallback_depths
+                    .image_for_samplecount(msaa.samples)
+                    .texture_view
+            };
+
+            let normal_view = if let Some(ViewPrepassTextures {
+                normal: Some(normal_prepass),
+                ..
+            }) = &maybe_prepass_textures
+            {
+                &normal_prepass.default_view
+            } else {
+                &fallback_images
+                    .image_for_samplecount(msaa.samples)
+                    .texture_view
+            };
+
+            let layout = if msaa.samples > 1 {
+                &mesh_pipeline.view_layout_multisampled
+            } else {
+                &mesh_pipeline.view_layout
+            };
+
             let view_bind_group = render_device.create_bind_group(&BindGroupDescriptor {
                 entries: &[
                     BindGroupEntry {
@@ -821,9 +913,17 @@ pub fn queue_mesh_view_bind_groups(
                         binding: 8,
                         resource: view_cluster_bindings.offsets_and_counts_binding().unwrap(),
                     },
+                    BindGroupEntry {
+                        binding: 9,
+                        resource: BindingResource::TextureView(depth_view),
+                    },
+                    BindGroupEntry {
+                        binding: 10,
+                        resource: BindingResource::TextureView(normal_view),
+                    },
                 ],
                 label: Some("mesh_view_bind_group"),
-                layout: &mesh_pipeline.view_layout,
+                layout,
             });
 
             commands.entity(entity).insert(MeshViewBindGroup {

--- a/crates/bevy_pbr/src/render/mesh_view_bindings.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_view_bindings.wgsl
@@ -40,3 +40,15 @@ var<storage> cluster_light_index_lists: ClusterLightIndexLists;
 @group(0) @binding(8)
 var<storage> cluster_offsets_and_counts: ClusterOffsetsAndCounts;
 #endif
+
+#ifdef MULTISAMPLED
+@group(0) @binding(9)
+var depth_prepass_texture: texture_depth_multisampled_2d;
+@group(0) @binding(10)
+var normal_prepass_texture: texture_multisampled_2d<f32>;
+#else
+@group(0) @binding(9)
+var depth_prepass_texture: texture_depth_2d;
+@group(0) @binding(10)
+var normal_prepass_texture: texture_2d<f32>;
+#endif

--- a/crates/bevy_pbr/src/render/pbr.wgsl
+++ b/crates/bevy_pbr/src/render/pbr.wgsl
@@ -11,6 +11,7 @@
 struct FragmentInput {
     @builtin(front_facing) is_front: bool,
     @builtin(position) frag_coord: vec4<f32>,
+    @builtin(sample_index) sample_index: u32,
     #import bevy_pbr::mesh_vertex_output
 };
 
@@ -76,6 +77,7 @@ fn fragment(in: FragmentInput) -> @location(0) vec4<f32> {
         pbr_input.N = prepare_normal(
             material.flags,
             in.world_normal,
+            // prepass_normal(in.frag_coord, in.sample_index),
 #ifdef VERTEX_TANGENTS
 #ifdef STANDARDMATERIAL_NORMAL_MAP
             in.world_tangent,

--- a/crates/bevy_pbr/src/render/utils.wgsl
+++ b/crates/bevy_pbr/src/render/utils.wgsl
@@ -21,3 +21,21 @@ fn hsv2rgb(hue: f32, saturation: f32, value: f32) -> vec3<f32> {
 fn random1D(s: f32) -> f32 {
     return fract(sin(s * 12.9898) * 43758.5453123);
 }
+
+fn prepass_normal(frag_coord: vec4<f32>, sample_index: u32) -> vec3<f32> {
+#ifdef MULTISAMPLED
+    let normal_sample: vec4<f32> = textureLoad(normal_prepass_texture, vec2<i32>(frag_coord.xy), i32(sample_index));
+#else
+    let normal_sample: vec4<f32> = textureLoad(normal_prepass_texture, vec2<i32>(frag_coord.xy), 0);
+#endif
+    return normal_sample.xyz * 2.0 - vec3<f32>(1.0);
+}
+
+fn prepass_depth(frag_coord: vec4<f32>, sample_index: u32) -> f32 {
+#ifdef MULTISAMPLED
+    let depth_sample: f32 = textureLoad(depth_prepass_texture, vec2<i32>(frag_coord.xy), i32(sample_index));
+#else
+    let depth_sample: f32 = textureLoad(depth_prepass_texture, vec2<i32>(frag_coord.xy), 0);
+#endif
+    return depth_sample;
+}

--- a/crates/bevy_render/src/texture/fallback_image.rs
+++ b/crates/bevy_render/src/texture/fallback_image.rs
@@ -1,13 +1,18 @@
 use crate::{render_resource::*, texture::DefaultImageSampler};
-use bevy_derive::Deref;
-use bevy_ecs::{prelude::FromWorld, system::Resource};
+use bevy_derive::{Deref, DerefMut};
+use bevy_ecs::{
+    prelude::{FromWorld, Res, ResMut},
+    system::{Resource, SystemParam},
+};
 use bevy_math::Vec2;
+use bevy_utils::HashMap;
+use std::marker::PhantomData;
 use wgpu::{Extent3d, TextureDimension, TextureFormat};
 
 use crate::{
     prelude::Image,
     renderer::{RenderDevice, RenderQueue},
-    texture::{BevyDefault, GpuImage, ImageSampler},
+    texture::{image::TextureFormatPixelInfo, BevyDefault, GpuImage, ImageSampler},
 };
 
 /// A [`RenderApp`](crate::RenderApp) resource that contains the default "fallback image",
@@ -17,36 +22,111 @@ use crate::{
 #[derive(Resource, Deref)]
 pub struct FallbackImage(GpuImage);
 
+fn fallback_image_new(
+    render_device: &RenderDevice,
+    render_queue: &RenderQueue,
+    default_sampler: &DefaultImageSampler,
+    format: TextureFormat,
+    samples: u32,
+) -> GpuImage {
+    let data = vec![255; format.pixel_size() as usize];
+
+    let mut image = Image::new_fill(Extent3d::default(), TextureDimension::D2, &data, format);
+
+    image.texture_descriptor.sample_count = samples;
+    image.texture_descriptor.usage |= TextureUsages::RENDER_ATTACHMENT;
+
+    let texture = match format.describe().sample_type {
+        // can't initialize depth textures with data
+        TextureSampleType::Depth => render_device.create_texture(&image.texture_descriptor),
+        _ => render_device.create_texture_with_data(
+            render_queue,
+            &image.texture_descriptor,
+            &image.data,
+        ),
+    };
+
+    let texture_view = texture.create_view(&TextureViewDescriptor::default());
+    let sampler = match image.sampler_descriptor {
+        ImageSampler::Default => (**default_sampler).clone(),
+        ImageSampler::Descriptor(descriptor) => render_device.create_sampler(&descriptor),
+    };
+    GpuImage {
+        texture,
+        texture_view,
+        texture_format: image.texture_descriptor.format,
+        sampler,
+        size: Vec2::new(
+            image.texture_descriptor.size.width as f32,
+            image.texture_descriptor.size.height as f32,
+        ),
+    }
+}
+
 impl FromWorld for FallbackImage {
     fn from_world(world: &mut bevy_ecs::prelude::World) -> Self {
         let render_device = world.resource::<RenderDevice>();
         let render_queue = world.resource::<RenderQueue>();
         let default_sampler = world.resource::<DefaultImageSampler>();
-        let image = Image::new_fill(
-            Extent3d::default(),
-            TextureDimension::D2,
-            &[255u8; 4],
-            TextureFormat::bevy_default(),
-        );
-        let texture = render_device.create_texture_with_data(
+        Self(fallback_image_new(
+            render_device,
             render_queue,
-            &image.texture_descriptor,
-            &image.data,
-        );
-        let texture_view = texture.create_view(&TextureViewDescriptor::default());
-        let sampler = match image.sampler_descriptor {
-            ImageSampler::Default => (**default_sampler).clone(),
-            ImageSampler::Descriptor(descriptor) => render_device.create_sampler(&descriptor),
-        };
-        Self(GpuImage {
-            texture,
-            texture_view,
-            texture_format: image.texture_descriptor.format,
-            sampler,
-            size: Vec2::new(
-                image.texture_descriptor.size.width as f32,
-                image.texture_descriptor.size.height as f32,
-            ),
+            default_sampler,
+            TextureFormat::bevy_default(),
+            1,
+        ))
+    }
+}
+
+#[derive(Resource, Deref, DerefMut, Default)]
+pub struct FallbackImageMsaaCache(HashMap<u32, GpuImage>);
+#[derive(Resource, Deref, DerefMut, Default)]
+pub struct FallbackImageDepthCache(HashMap<u32, GpuImage>);
+
+#[derive(SystemParam)]
+pub struct FallbackImagesMsaa<'w, 's> {
+    cache: ResMut<'w, FallbackImageMsaaCache>,
+    render_device: Res<'w, RenderDevice>,
+    render_queue: Res<'w, RenderQueue>,
+    default_sampler: Res<'w, DefaultImageSampler>,
+    #[system_param(ignore)]
+    _p: PhantomData<&'s ()>,
+}
+
+impl<'w, 's> FallbackImagesMsaa<'w, 's> {
+    pub fn image_for_samplecount(&mut self, sample_count: u32) -> &GpuImage {
+        self.cache.entry(sample_count).or_insert_with(|| {
+            fallback_image_new(
+                &self.render_device,
+                &self.render_queue,
+                &self.default_sampler,
+                TextureFormat::bevy_default(),
+                sample_count,
+            )
+        })
+    }
+}
+
+#[derive(SystemParam)]
+pub struct FallbackImagesDepth<'w, 's> {
+    cache: ResMut<'w, FallbackImageDepthCache>,
+    render_device: Res<'w, RenderDevice>,
+    render_queue: Res<'w, RenderQueue>,
+    default_sampler: Res<'w, DefaultImageSampler>,
+    #[system_param(ignore)]
+    _p: PhantomData<&'s ()>,
+}
+
+impl<'w, 's> FallbackImagesDepth<'w, 's> {
+    pub fn image_for_samplecount(&mut self, sample_count: u32) -> &GpuImage {
+        self.cache.entry(sample_count).or_insert_with(|| {
+            fallback_image_new(
+                &self.render_device,
+                &self.render_queue,
+                &self.default_sampler,
+                TextureFormat::Depth32Float,
+                sample_count,
+            )
         })
     }
 }

--- a/crates/bevy_render/src/texture/mod.rs
+++ b/crates/bevy_render/src/texture/mod.rs
@@ -80,6 +80,8 @@ impl Plugin for ImagePlugin {
                 .insert_resource(DefaultImageSampler(default_sampler))
                 .init_resource::<TextureCache>()
                 .init_resource::<FallbackImage>()
+                .init_resource::<FallbackImageMsaaCache>()
+                .init_resource::<FallbackImageDepthCache>()
                 .add_system_to_stage(RenderStage::Cleanup, update_texture_cache_system);
         }
     }

--- a/examples/3d/3d_scene.rs
+++ b/examples/3d/3d_scene.rs
@@ -4,16 +4,16 @@ use bevy::{
     core_pipeline::core_3d::DepthPrepassSettings,
     prelude::*,
     reflect::TypeUuid,
-    render::{
-        render_asset::RenderAssets,
-        render_resource::{AsBindGroup, AsBindGroupShaderType, ShaderType},
-    },
+    render::render_resource::{AsBindGroup, ShaderRef},
 };
 
 fn main() {
     App::new()
+        .insert_resource(Msaa { samples: 1 })
         .add_plugins(DefaultPlugins)
+        .add_plugin(MaterialPlugin::<CustomMaterial>::default())
         .add_startup_system(setup)
+        .add_system(rotate)
         .run();
 }
 
@@ -28,6 +28,16 @@ pub struct CustomMaterial {
     alpha_mode: AlphaMode,
 }
 
+impl Material for CustomMaterial {
+    fn fragment_shader() -> ShaderRef {
+        "shaders/custom_material.wgsl".into()
+    }
+
+    fn alpha_mode(&self) -> AlphaMode {
+        self.alpha_mode
+    }
+}
+
 /// set up a simple 3D scene
 fn setup(
     mut commands: Commands,
@@ -38,16 +48,24 @@ fn setup(
     // plane
     commands.spawn_bundle(PbrBundle {
         mesh: meshes.add(Mesh::from(shape::Plane { size: 5.0 })),
-        material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
+        material: materials.add(StandardMaterial {
+            unlit: true,
+            ..Color::rgb(0.3, 0.5, 0.3).into()
+        }),
         ..default()
     });
     // cube
-    commands.spawn_bundle(PbrBundle {
-        mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
-        material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
-        transform: Transform::from_xyz(0.0, 0.5, 0.0),
-        ..default()
-    });
+    commands
+        .spawn_bundle(PbrBundle {
+            mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
+            material: materials.add(StandardMaterial {
+                unlit: true,
+                ..Color::rgb(0.8, 0.7, 0.6).into()
+            }),
+            transform: Transform::from_xyz(-1.0, 0.5, 0.0),
+            ..default()
+        })
+        .insert(Rotates);
     // cube
     commands.spawn_bundle(MaterialMeshBundle {
         mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
@@ -56,7 +74,7 @@ fn setup(
             color_texture: None,
             alpha_mode: AlphaMode::Opaque,
         }),
-        transform: Transform::from_xyz(0.0, 0.5, 0.0),
+        transform: Transform::from_xyz(1.0, 0.5, 0.0),
         ..default()
     });
     // light
@@ -76,6 +94,18 @@ fn setup(
             ..default()
         })
         .insert(DepthPrepassSettings {
+            depth_resource: true,
             output_normals: true,
         });
+}
+
+#[derive(Component)]
+struct Rotates;
+
+fn rotate(mut q: Query<&mut Transform, With<Rotates>>, time: Res<Time>) {
+    for mut t in q.iter_mut() {
+        let rot =
+            (time.seconds_since_startup().sin() * 0.5 + 0.5) as f32 * std::f32::consts::PI * 2.0;
+        t.rotation = Quat::from_rotation_z(rot);
+    }
 }


### PR DESCRIPTION


still todo: use custom material vertex shader

done:

    add custom material plugin (works for prepass as long as the vertex shader is left as default)

add bindable depth texture output

    ViewNormalsTexture -> ViewPrepassTextures, include depth texture
    settings -> include depth_resource: bool
    copy depth output so it can be bound

bind to mesh view

    create multisampled pipeline layout
    select normal/multisampled layout based on samples in specialization
    add fallback sysparams to generate required fallbacks
    bind depth and normal textures or fallbacks to view group
    add bindings to mesh_view_bindings.wgsl
    add helpers to utils (should not live here ultimately though because they use the view bindings)

tested for msaa on/off, depth prepass on/off. not tested changing msaa at runtime, should be fine though.
