### PR TITLE
batching

### DIFF
--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -21,7 +21,7 @@ use bevy_ecs::{
 };
 use bevy_math::{Affine3, Affine3A, Mat4, Vec2, Vec3Swizzles, Vec4};
 use bevy_render::{
-    batching::{batch_render_phase, BatchMeta, NoAutomaticBatching},
+    batching::{batch_render_phase, NoAutomaticBatching},
     globals::{GlobalsBuffer, GlobalsUniform},
     mesh::{
         skinning::{SkinnedMesh, SkinnedMeshInverseBindposes},
@@ -393,7 +393,6 @@ pub fn extract_skinned_meshes(
 ///   result of the `prepare_mesh_uniforms` system, e.g. due to having to split
 ///   data across separate uniform bindings within the same buffer due to the
 ///   maximum uniform buffer binding size.
-#[derive(PartialEq, Eq)]
 struct BatchMeta3d {
     /// The pipeline id encompasses all pipeline configuration including vertex
     /// buffers and layouts, shaders and their specializations, bind group
@@ -408,13 +407,14 @@ struct BatchMeta3d {
     dynamic_offset: Option<NonMaxU32>,
 }
 
-impl BatchMeta<BatchMeta3d> for BatchMeta3d {
+impl PartialEq for BatchMeta3d {
     #[inline]
-    fn matches(&self, other: &BatchMeta3d) -> bool {
+    fn eq(&self, other: &BatchMeta3d) -> bool {
         self.pipeline_id == other.pipeline_id
             && self.draw_function_id == other.draw_function_id
             && self.mesh_asset_id == other.mesh_asset_id
             && (self.mesh_flags & (MeshFlags::SKINNED | MeshFlags::MORPH_TARGETS).bits()) == 0
+            && (other.mesh_flags & (MeshFlags::SKINNED | MeshFlags::MORPH_TARGETS).bits()) == 0
             && self.dynamic_offset == other.dynamic_offset
             && self.material_bind_group_id == other.material_bind_group_id
     }

--- a/crates/bevy_render/src/batching/mod.rs
+++ b/crates/bevy_render/src/batching/mod.rs
@@ -1,87 +1,46 @@
 use bevy_ecs::component::Component;
 use nonmax::NonMaxU32;
 
-use crate::render_phase::{CachedRenderPipelinePhaseItem, PhaseItem, RenderPhase};
+use crate::render_phase::{CachedRenderPipelinePhaseItem, RenderPhase};
 
 /// Add this component to mesh entities to disable automatic batching
 #[derive(Component)]
 pub struct NoAutomaticBatching;
 
-pub trait BatchMeta<T: BatchMeta<T>> {
-    fn matches(&self, other: &T) -> bool;
-}
-
-struct BatchState<T: BatchMeta<T>> {
-    meta: Option<T>,
-    /// The base index in the object data binding's array
-    index: Option<NonMaxU32>,
-    /// The dynamic offset of the data binding
-    dynamic_offset: Option<NonMaxU32>,
-    /// The number of entities in the batch
-    count: u32,
-    item_index: usize,
-}
-
-impl<T: BatchMeta<T>> Default for BatchState<T> {
-    fn default() -> Self {
-        Self {
-            meta: Default::default(),
-            index: Default::default(),
-            dynamic_offset: Default::default(),
-            count: Default::default(),
-            item_index: Default::default(),
-        }
-    }
-}
-
-fn update_batch_data<I: PhaseItem, T: BatchMeta<T>>(item: &mut I, batch: &BatchState<T>) {
-    let BatchState {
-        count,
-        index,
-        dynamic_offset,
-        ..
-    } = batch;
-    let index = index.map_or(0, |index| index.get());
-    *item.batch_range_mut() = index..(index + *count);
-    *item.dynamic_offset_mut() = *dynamic_offset;
-}
-
 /// Batch the items in a render phase. This means comparing metadata needed to draw each phase item
 /// and trying to combine the draws into a batch.
 pub fn batch_render_phase<
     I: CachedRenderPipelinePhaseItem,
-    T: BatchMeta<T>, // Batch metadata used for distinguishing batches
+    T: PartialEq, // Batch metadata used for distinguishing batches
 >(
     phase: &mut RenderPhase<I>,
-    mut get_batch_meta: impl FnMut(&I) -> Option<(T, Option<NonMaxU32>, Option<NonMaxU32>)>,
+    mut get_batch_meta: impl FnMut(&I) -> Option<(T, NonMaxU32, Option<NonMaxU32>)>,
 ) {
-    let mut batch = BatchState::<T>::default();
-    for i in 0..phase.items.len() {
-        let item = &phase.items[i];
-        let Some((batch_meta, index, dynamic_offset)) = get_batch_meta(item) else {
-            // It is necessary to start a new batch if an entity not matching the query is
-            // encountered. This can be achieved by resetting the batch meta.
-            batch.meta = None;
+    // we iterate in reverse so that we can write to the last item of the current batch, and still skip the 
+    // right number of phase items when iterating forwards in the Render stage
+    let mut items = phase.items.iter_mut().rev().peekable();
+    let mut batch_start_index = None;
+    let mut next_batch = items.peek().and_then(|item| get_batch_meta(item));
+    while let Some(item) = items.next() {
+        // get current batch meta and update next batch meta
+        let Some((batch_meta, index, dynamic_offset)) = std::mem::replace(
+            &mut next_batch,
+            items.peek().and_then(|item| get_batch_meta(item)),
+        ) else {
+            // if the current phase item doesn't match the query, we don't modify it
             continue;
         };
-        if !batch
-            .meta
-            .as_ref()
-            .map_or(false, |meta| meta.matches(&batch_meta))
-        {
-            if batch.count > 0 {
-                update_batch_data(&mut phase.items[batch.item_index], &batch);
-            }
 
-            batch.meta = Some(batch_meta);
-            batch.index = index;
-            batch.dynamic_offset = dynamic_offset;
-            batch.count = 0;
-            batch.item_index = i;
+        // record the start index if we are beginning a new batch
+        if batch_start_index.is_none() {
+            batch_start_index = Some(index);
         }
-        batch.count += 1;
-    }
-    if !phase.items.is_empty() && batch.count > 0 {
-        update_batch_data(&mut phase.items[batch.item_index], &batch);
+
+        if Some(&batch_meta) != next_batch.as_ref().map(|(meta, ..)| meta) {
+            // next item doesn't match, update the phase item to render this batch
+            *item.batch_range_mut() = batch_start_index.take().unwrap().get()..index.get() + 1;
+            *item.dynamic_offset_mut() = dynamic_offset;
+            batch_start_index = None;
+        }
     }
 }

--- a/crates/bevy_render/src/render_resource/batched_uniform_buffer.rs
+++ b/crates/bevy_render/src/render_resource/batched_uniform_buffer.rs
@@ -77,7 +77,7 @@ impl<T: GpuArrayBufferable> BatchedUniformBuffer<T> {
 
     pub fn push(&mut self, component: T) -> GpuArrayBufferIndex<T> {
         let result = GpuArrayBufferIndex {
-            index: NonMaxU32::new(self.temp.0.len() as u32),
+            index: NonMaxU32::new(self.temp.0.len() as u32).unwrap(),
             dynamic_offset: NonMaxU32::new(self.current_offset),
             element_type: PhantomData,
         };

--- a/crates/bevy_render/src/render_resource/gpu_array_buffer.rs
+++ b/crates/bevy_render/src/render_resource/gpu_array_buffer.rs
@@ -53,7 +53,7 @@ impl<T: GpuArrayBufferable> GpuArrayBuffer<T> {
         match self {
             GpuArrayBuffer::Uniform(buffer) => buffer.push(value),
             GpuArrayBuffer::Storage((_, buffer)) => {
-                let index = NonMaxU32::new(buffer.len() as u32);
+                let index = NonMaxU32::new(buffer.len() as u32).unwrap();
                 buffer.push(value);
                 GpuArrayBufferIndex {
                     index,
@@ -122,19 +122,9 @@ impl<T: GpuArrayBufferable> GpuArrayBuffer<T> {
 #[derive(Component, Clone)]
 pub struct GpuArrayBufferIndex<T: GpuArrayBufferable> {
     /// The index to use in a shader into the array.
-    pub index: Option<NonMaxU32>,
+    pub index: NonMaxU32,
     /// The dynamic offset to use when setting the bind group in a pass.
     /// Only used on platforms that don't support storage buffers.
     pub dynamic_offset: Option<NonMaxU32>,
     pub element_type: PhantomData<T>,
-}
-
-impl<T: GpuArrayBufferable> Default for GpuArrayBufferIndex<T> {
-    fn default() -> Self {
-        Self {
-            index: None,
-            dynamic_offset: None,
-            element_type: Default::default(),
-        }
-    }
 }

--- a/crates/bevy_sprite/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite/src/mesh2d/mesh.rs
@@ -10,7 +10,7 @@ use bevy_ecs::{
 use bevy_math::{Affine3, Affine3A, Vec2, Vec3Swizzles, Vec4};
 use bevy_reflect::Reflect;
 use bevy_render::{
-    batching::{batch_render_phase, BatchMeta, NoAutomaticBatching},
+    batching::{batch_render_phase, NoAutomaticBatching},
     globals::{GlobalsBuffer, GlobalsUniform},
     mesh::{GpuBufferInfo, Mesh, MeshVertexBufferLayout},
     render_asset::RenderAssets,
@@ -253,16 +253,6 @@ struct BatchMeta2d {
     material2d_bind_group_id: Option<Material2dBindGroupId>,
     mesh_asset_id: AssetId<Mesh>,
     dynamic_offset: Option<NonMaxU32>,
-}
-
-impl BatchMeta<BatchMeta2d> for BatchMeta2d {
-    fn matches(&self, other: &BatchMeta2d) -> bool {
-        self.pipeline_id == other.pipeline_id
-            && self.draw_function_id == other.draw_function_id
-            && self.mesh_asset_id == other.mesh_asset_id
-            && self.dynamic_offset == other.dynamic_offset
-            && self.material2d_bind_group_id == other.material2d_bind_group_id
-    }
 }
 
 #[allow(clippy::too_many_arguments)]


### PR DESCRIPTION
up to you if you prefer this

- remove `BatchMeta` trait, use `T: PartialEq` instead
- remove BatchState, track directly in the function
- make GpuArrayIndex::index non-optional
- added other.flags & MORPH | SKINNING == 0 to `BatchMeta3d`